### PR TITLE
feat: add TLS gRPC server on port 50053 for SSL testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ replay_pid*
 /.idea
 /build
 .DS_Store
+
+# Generated TLS cert/key — created at build time, never commit the private key
+src/main/resources/server.key
+src/main/resources/server.crt

--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,19 @@ protobuf {
 	}
 }
 
+// Generate self-signed TLS cert/key for the test gRPC server if not already present
+tasks.register('generateTlsCert', Exec) {
+    def certFile = file('src/main/resources/server.crt')
+    def keyFile  = file('src/main/resources/server.key')
+    onlyIf { !certFile.exists() || !keyFile.exists() }
+    commandLine 'openssl', 'req', '-x509', '-newkey', 'rsa:2048',
+            '-keyout', keyFile.absolutePath,
+            '-out', certFile.absolutePath,
+            '-days', '3650', '-nodes', '-subj', '/CN=localhost'
+    doFirst { mkdir 'src/main/resources' }
+}
+processResources.dependsOn generateTlsCert
+
 // Configure JAR tasks
 jar {
 	manifest {

--- a/src/main/java/org/conductoross/grpcbin/GRPCServer.java
+++ b/src/main/java/org/conductoross/grpcbin/GRPCServer.java
@@ -1,17 +1,21 @@
 package org.conductoross.grpcbin;
 
-import io.grpc.BindableService;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
+import io.grpc.netty.shaded.io.grpc.netty.GrpcSslContexts;
+import io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder;
+import io.grpc.netty.shaded.io.netty.handler.ssl.SslContextBuilder;
 import io.grpc.protobuf.services.ProtoReflectionService;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.concurrent.TimeUnit;
 
 public class GRPCServer {
 
     private Server noAuthServer;
     private Server authServer;
+    private Server tlsServer;
 
     private void start() throws IOException {
         // Server without authentication (port 50051)
@@ -33,6 +37,19 @@ public class GRPCServer {
                 .start();
         System.out.println("🔐 Server WITH auth started on port " + authPort + " (requires Bearer token: test-bearer-token-123)");
 
+        // TLS server with auth (port 50053) — self-signed cert loaded from resources
+        int tlsPort = 50053;
+        InputStream certChain = GRPCServer.class.getResourceAsStream("/server.crt");
+        InputStream privateKey = GRPCServer.class.getResourceAsStream("/server.key");
+        tlsServer = NettyServerBuilder.forPort(tlsPort)
+                .sslContext(GrpcSslContexts.configure(SslContextBuilder.forServer(certChain, privateKey)).build())
+                .addService(new HelloWorldServiceImpl())
+                .addService(ProtoReflectionService.newInstance())
+                .intercept(new AuthInterceptor())
+                .build()
+                .start();
+        System.out.println("🔒 Server WITH TLS+auth started on port " + tlsPort + " (self-signed cert, requires Bearer token: test-bearer-token-123)");
+
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
             System.out.println("Shutting down gRPC servers");
             GRPCServer.this.stop();
@@ -49,6 +66,10 @@ public class GRPCServer {
                 authServer.shutdown().awaitTermination(5, TimeUnit.SECONDS);
                 System.out.println("Auth server shut down");
             }
+            if (tlsServer != null) {
+                tlsServer.shutdown().awaitTermination(5, TimeUnit.SECONDS);
+                System.out.println("TLS server shut down");
+            }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
         }
@@ -60,6 +81,9 @@ public class GRPCServer {
         }
         if (authServer != null) {
             authServer.awaitTermination();
+        }
+        if (tlsServer != null) {
+            tlsServer.awaitTermination();
         }
     }
 


### PR DESCRIPTION
## Summary
- Adds a 3rd gRPC server on port `50053` with TLS + Bearer token auth using a self-signed certificate
- TLS cert/key are generated at build time via a Gradle `generateTlsCert` task (uses `openssl`) — never committed to VCS
- Both `server.crt` and `server.key` are gitignored

## Ports
| Port | Auth | TLS |
|------|------|-----|
| 50051 | None | No |
| 50052 | Bearer token | No |
| 50053 | Bearer token | Yes (self-signed, client needs `trustCert=true`) |

## Why
Used by Conductor e2e tests to verify that gRPC tasks with `useSSL: true` and `trustCert: true` correctly establish TLS connections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)